### PR TITLE
Fixed urdfs with biotacs and dummy palm

### DIFF
--- a/sr_description/hand/xacro/finger/biotac/biotac.urdf.xacro
+++ b/sr_description/hand/xacro/finger/biotac/biotac.urdf.xacro
@@ -154,20 +154,20 @@ xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom">
         <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0"
         izz="0.0" />
       </inertial>
-      <visual>
+      <!--visual>
         <geometry>
           <sphere radius="0.002" />
         </geometry>
-      </visual>
+      </visual-->
     </link>
     <gazebo reference="${prefix}${joint_prefix}tip">
       <material name="Gazebo/RedGlow" />
     </gazebo>
     <joint name="${prefix}${joint_prefix}tip"
     type="fixed">
-      <parent link="${prefix}${link_prefix}middle" />
+      <parent link="${prefix}${link_prefix}_J1_dummy" />
       <child link="${prefix}${link_prefix}tip" />
-      <origin xyz="0.0 -0.009 ${0.008+0.044}" rpy="0 0 -1.571" />
+      <origin xyz="0.0 0.004 0.029" rpy="0 0 0" />
       <!-- approximated only FIXME -->
     </joint>
   </xacro:macro>

--- a/sr_description/hand/xacro/one_finger_unit.urdf.xacro
+++ b/sr_description/hand/xacro/one_finger_unit.urdf.xacro
@@ -18,7 +18,7 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
     <!-- Forearm -->
     <xacro:forearm muscle="${muscle}" prefix="${prefix}" />
     <!-- Dummy Palm -->
-    <link name="${prefix}dummy_palm">
+    <link name="${prefix}palm">
       <inertial>
         <mass value="0.010" />
         <origin xyz="0 0 0" />
@@ -27,21 +27,21 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
       </inertial>
       <visual>
         <origin xyz="0 0 0.0505" rpy="0 0 0" />
-        <geometry name="${prefix}dummy_palm_visual">
+        <geometry name="${prefix}palm_visual">
           <box size="0.015 0.015 0.110" />
         </geometry>
         <material name="Grey" />
       </visual>
       <collision>
         <origin xyz="0 0 0.0" rpy="0 0 0" />
-        <geometry name="${prefix}dummy_palm_collision_geom">
+        <geometry name="${prefix}palm_collision_geom">
           <box size="0.015 0.015 0.110" />
         </geometry>
       </collision>
     </link>
     <joint name="${prefix}forearm_to_dummy" type="fixed">
       <parent link="${prefix}forearm" />
-      <child link="${prefix}dummy_palm" />
+      <child link="${prefix}palm" />
       <origin xyz="${reflect*0.011} 0.010 0.22"
       rpy="0 0 ${M_PI}" />
     </joint>
@@ -51,7 +51,7 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
     <xacro:finger muscletrans="${muscletrans}" lf="false"
     bio="${bio}" bt_sp="${bt_sp}" ubi="${ubi}" eli="${eli}" prefix="${prefix}"
     reflect="${reflect}" link_prefix="mf" joint_prefix="MF"
-    parent="${prefix}dummy_palm">
+    parent="${prefix}palm">
       <origin xyz="0.0 0 0.116" rpy="0 0 0" />
       <axis xyz="0 ${-1*reflect} 0" />
     </xacro:finger>

--- a/sr_description/hand/xacro/thumb/thdistal.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thdistal.urdf.xacro
@@ -100,20 +100,20 @@ xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom">
           <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0"
           izz="0" />
         </inertial>
-        <visual>
+        <!--visual>
           <geometry>
             <sphere radius="0.002" />
           </geometry>
-        </visual>
+        </visual-->
       </link>
       <gazebo reference="${prefix}thtip">
         <material name="LightGrey" />
       </gazebo>
       <joint name="${prefix}thtip" type="fixed">
-        <parent link="${prefix}thmiddle" />
+        <parent link="${prefix}thdistal_J1_dummy" />
         <child link="${prefix}thtip" />
-        <origin xyz="-0.009 0.0 ${0.01+0.044}"
-        rpy="0 0 ${-M_PI/2}" />
+        <origin xyz="0.0 0.004 ${0.032}"
+        rpy="0 0 0" />
         <!-- approximated only FIXME -->
       </joint>
     </xacro:if>


### PR DESCRIPTION
This seems to solve the issue of moveit with the hands with biotac. Now the tip joint is fixed relative to the rh_ff_J1_dummy. As shown in the first finger tree here:
![frames](https://cloud.githubusercontent.com/assets/12493239/10304790/2fcd90ce-6c14-11e5-97c9-754fb605c1a4.png)

I also commented out the visualization of the tip as was colliding with the other links.

Also fixed a problem with the one finger hand that had a different name for the palm. 

With this then all hands will work with moveit except:
shadowhand_edc_muscle_biotac.urdf.xacro
shadowhand_edc_muscle.urdf.xacro
shadowhand_left_edc_muscle.urdf.xacro
sr_three_finger_edc_muscle_biotac.urdf.xacro
