### PR TITLE
Cylindrical forearm collision model

### DIFF
--- a/sr_description/hand/xacro/forearm/forearm.urdf.xacro
+++ b/sr_description/hand/xacro/forearm/forearm.urdf.xacro
@@ -33,7 +33,8 @@
         <xacro:unless value="${muscle}">
           <origin xyz="0 0 0.092" rpy="0 0 0" />
           <geometry name="${prefix}forearm_collision">
-            <box size="0.140 0.140 0.184" />
+            <cylinder radius="0.07" length="0.184"/>
+            <!--<box size="0.140 0.140 0.184" />-->
           </geometry>
         </xacro:unless>
       </collision>

--- a/sr_description/robots/shadowhand_edc_muscle.urdf.xacro
+++ b/sr_description/robots/shadowhand_edc_muscle.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_muscle">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="rh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="rh_forearm_disk" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <xacro:shadowhand muscletrans="true" muscle="true" bio="false" bt_sp="false"
   ubi="false" eli="false" reflect="1.0" prefix="rh_" />
   <link name="rh_forearm_disk">

--- a/sr_description/robots/shadowhand_edc_muscle_biotac.urdf.xacro
+++ b/sr_description/robots/shadowhand_edc_muscle_biotac.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_motor">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="rh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="rh_forearm_disk" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <!-- C6 hand with BioTAC sensor
   (C) 2012 fnh, hendrich@informatik.uni-hamburg.de
 -->

--- a/sr_description/robots/shadowhand_left_edc_muscle.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_edc_muscle.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_muscle">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="lh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="lh_forearm_disk" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <xacro:shadowhand muscletrans="true" muscle="true" bio="false" bt_sp="false"
   ubi="false" eli="false" reflect="-1.0" prefix="lh_" />
   <link name="lh_forearm_disk">

--- a/sr_description/robots/shadowhand_left_motor.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_motor.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_motor">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="lh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="lh_forearm" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <xacro:shadowhand muscletrans="false" muscle="false" bio="false" bt_sp="false"
   ubi="false" eli="false" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/shadowhand_left_motor_biotac.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_motor_biotac.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_motor">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="lh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="lh_forearm" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <xacro:shadowhand muscletrans="false" muscle="false" bio="true" bt_sp="false"
   ubi="false" eli="false" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/shadowhand_left_muscle.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_muscle.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_muscle">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="lh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="lh_forearm_disk" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <xacro:shadowhand muscletrans="false" muscle="true" bio="false" bt_sp="false"
   ubi="false" eli="false" reflect="-1.0" prefix="lh_" />
   <link name="lh_forearm_disk">

--- a/sr_description/robots/shadowhand_motor.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor.urdf.xacro
@@ -6,6 +6,13 @@
     <xacro:include filename="$(find sr_description)/materials.urdf.xacro"/>
     <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro"/>
     <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro"/>
+    <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+    <link name="world" />
+    <joint name="rh_world_joint" type="fixed">
+      <parent link="world" />
+      <child link="rh_forearm" />
+      <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+    </joint>
     <xacro:shadowhand muscletrans="false" muscle="false" bio="false" bt_sp="false"
                       ubi="false" eli="false" reflect="1.0" prefix="rh_"/>
 </robot>

--- a/sr_description/robots/shadowhand_motor_biotac.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_biotac.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_motor">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="rh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="rh_forearm" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <!-- C6 hand with BioTAC sensor
   (C) 2012 fnh, hendrich@informatik.uni-hamburg.de
 -->

--- a/sr_description/robots/shadowhand_motor_btsp.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_btsp.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_motor">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="rh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="rh_forearm" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <xacro:shadowhand muscletrans="false" muscle="false" bio="false" bt_sp="true"
   ubi="false" eli="false" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_ellipsoid.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_ellipsoid.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_motor">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="rh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="rh_forearm" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <xacro:shadowhand muscletrans="false" muscle="false" bio="false" bt_sp="false"
   ubi="false" eli="true" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_ff_biotac.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_ff_biotac.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_motor">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/ff_biotac_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="rh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="rh_forearm" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <!-- bio is used for all other fingers since ff is forced at bio -->
   <xacro:shadowhand muscletrans="false" muscle="false" bio="false" bt_sp="false"
   ubi="false" eli="false" reflect="1.0" prefix="rh_" />

--- a/sr_description/robots/shadowhand_motor_th_ff_rf_ellipsoid.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_th_ff_rf_ellipsoid.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_motor">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/th_ff_rf_ellipsoid_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="rh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="rh_forearm" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <!-- eli is used for other fingers since th, ff and rf are forced to eli -->
   <xacro:shadowhand muscletrans="false" muscle="false" bio="false" bt_sp="false"
   ubi="false" eli="false" reflect="1.0" prefix="rh_" />

--- a/sr_description/robots/shadowhand_muscle.urdf.xacro
+++ b/sr_description/robots/shadowhand_muscle.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_muscle">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="rh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="rh_forearm_disk" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <xacro:shadowhand muscletrans="false" muscle="true" bio="false" bt_sp="false"
   ubi="false" eli="false" reflect="1.0" prefix="rh_" />
   <link name="rh_forearm_disk">

--- a/sr_description/robots/shadowhand_muscle_biotac.urdf.xacro
+++ b/sr_description/robots/shadowhand_muscle_biotac.urdf.xacro
@@ -9,6 +9,13 @@ name="shadowhand_motor">
   <!-- C6 hand with BioTAC sensor
   (C) 2012 fnh, hendrich@informatik.uni-hamburg.de
 -->
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="rh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="rh_forearm_disk" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <xacro:shadowhand muscletrans="false" muscle="true" bio="true" bt_sp="false"
   ubi="false" eli="false" reflect="1.0" prefix="rh_" />
   <link name="rh_forearm_disk">

--- a/sr_description/robots/sr_one_finger_motor.urdf.xacro
+++ b/sr_description/robots/sr_one_finger_motor.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_motor">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/one_finger_unit.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="rh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="rh_forearm" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <xacro:shadowhand muscletrans="false" muscle="false" bio="false" bt_sp="false"
   ubi="false" eli="false" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/sr_three_finger_edc_muscle_biotac.urdf.xacro
+++ b/sr_description/robots/sr_three_finger_edc_muscle_biotac.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_motor">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/three_fingers_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="rh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="rh_forearm" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <xacro:shadowhand muscletrans="true" muscle="true" bio="true" bt_sp="false"
   ubi="false" eli="false" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/sr_three_finger_motor.urdf.xacro
+++ b/sr_description/robots/sr_three_finger_motor.urdf.xacro
@@ -6,6 +6,13 @@ name="shadowhand_motor">
   <xacro:include filename="$(find sr_description)/materials.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/three_fingers_hand.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro" />
+  <!-- hand with cylindrical base drifts in gazebo, attach it to the world -->
+  <link name="world" />
+  <joint name="rh_world_joint" type="fixed">
+    <parent link="world" />
+    <child link="rh_forearm" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
   <xacro:shadowhand muscletrans="false" muscle="false" bio="false" bt_sp="false"
   ubi="false" eli="false" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/test/hand_test.rviz
+++ b/sr_description/test/hand_test.rviz
@@ -8,7 +8,7 @@ Panels:
         - /Status1
         - /RobotModel1
       Splitter Ratio: 0.446809
-    Tree Height: 948
+    Tree Height: 944
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -59,181 +59,155 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
-        ff_J1_dummy:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-        ffadapter:
+        lh_ffdistal:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        ffbiotac:
+        lh_ffknuckle:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        ffknuckle:
+        lh_ffmiddle:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        ffproximal:
+        lh_ffproximal:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        fftip:
+        lh_fftip:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        lh_forearm:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        forearm:
+        lh_lfdistal:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        forearm_disk:
+        lh_lfknuckle:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        lf_J1_dummy:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-        lfadapter:
+        lh_lfmetacarpal:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        lfbiotac:
+        lh_lfmiddle:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        lfknuckle:
+        lh_lfproximal:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        lfmetacarpal:
+        lh_lftip:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        lh_mfdistal:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        lfproximal:
+        lh_mfknuckle:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        lftip:
+        lh_mfmiddle:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        mf_J1_dummy:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-        mfadapter:
+        lh_mfproximal:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        mfbiotac:
+        lh_mftip:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        lh_palm:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        mfknuckle:
+        lh_rfdistal:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        mfproximal:
+        lh_rfknuckle:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        mftip:
+        lh_rfmiddle:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        palm:
+        lh_rfproximal:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        rf_J1_dummy:
+        lh_rftip:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        rfadapter:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        rfbiotac:
+        lh_thbase:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        rfknuckle:
+        lh_thdistal:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        rfproximal:
+        lh_thhub:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        rftip:
+        lh_thmiddle:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        thbase:
+        lh_thproximal:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        thbiotac:
+        lh_thtip:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        lh_wrist:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        thbiotac_J1_dummy:
+        world:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        thhub:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        thmiddle:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        thproximal:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        thtip:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        wrist:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
       Name: RobotModel
       Robot Description: /robot_description
       TF Prefix: ""
@@ -257,7 +231,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 255; 255; 255
-    Fixed Frame: forearm
+    Fixed Frame: world
     Frame Rate: 30
   Name: root
   Tools:
@@ -298,10 +272,10 @@ Visualization Manager:
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1176
+  Height: 1174
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000010f000003f5fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000041000003f5000000dd00fffffffb0000000c00430061006d0065007200610000000420000000160000000000000000fb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d006100670065010000033c000000cd0000000000000000000000010000010f000002bbfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000002bb000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000006360000003efc0100000002fb0000000800540069006d00650100000000000006360000028000fffffffb0000000800540069006d0065010000000000000450000000000000000000000521000003f500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000010f000003f1fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006700fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000043000003f1000000e300fffffffb0000000c00430061006d0065007200610000000420000000160000000000000000fb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d006100670065010000033c000000cd0000000000000000000000010000010f000002bbfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000002bb000000b300fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000006360000003efc0100000002fb0000000800540069006d00650100000000000006360000023a00fffffffb0000000800540069006d0065010000000000000450000000000000000000000521000003f100000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:


### PR DESCRIPTION
The box forearm collision model was changed to avoid the hand drifting in gazebo. The box shape is problematic in planning as it is much bigger than the real shape. 

We agreed with @ugocupcic  that attaching the hand to the world in the robots/*.xacro was ok as this is done anyway in the new sr_robot_launch when creating the robots.

So I changed the forearm collision model to cylinder again and attached the forearm to the world

Tested visually with all models (fixed also the rviz.cfg to use world as fixed frame)
Tested in gazebo with shadowhand_motor only. Does not drift anymore.
