### PR TITLE
add a child element called imu, to be compatible with SensorParser

### DIFF
--- a/sr_description/hand/xacro/palm/imu.urdf.xacro
+++ b/sr_description/hand/xacro/palm/imu.urdf.xacro
@@ -1,5 +1,5 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="shadowhand_motor">
-  <xacro:macro name="imu" params="prefix">
+  <xacro:macro name="imu_sensor" params="prefix">
     <link name="${prefix}imu"/>
     <joint name="${prefix}palm_to_imu" type="fixed">
       <parent link="${prefix}palm" />
@@ -10,6 +10,7 @@
     <sensor name="${prefix}imu" update_rate="100">
       <parent link="${prefix}imu"/>
       <origin xyz="0 0 0" rpy="0 0 0"/>
+      <imu />
     </sensor>
   </xacro:macro>
 </robot>

--- a/sr_description/hand/xacro/palm/palm.urdf.xacro
+++ b/sr_description/hand/xacro/palm/palm.urdf.xacro
@@ -108,7 +108,7 @@ xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom">
       <implicitSpringDamper>1</implicitSpringDamper>
     </gazebo>
     <!--imu-->
-    <xacro:imu prefix="${prefix}"/>
+    <xacro:imu_sensor prefix="${prefix}"/>
     <!-- extensions -->
     <xacro:shadowhand_palm_transmission muscletrans="${muscletrans}"
     prefix="${prefix}" />

--- a/sr_description/hand/xacro/palm/palm_lite.urdf.xacro
+++ b/sr_description/hand/xacro/palm/palm_lite.urdf.xacro
@@ -88,7 +88,7 @@ xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom">
     <link name="${prefix}manipulator" />
     <!-- No wrist joints in a Lite palm -->
     <!-- extensions -->
-    <xacro:imu prefix="${prefix}" />
+    <xacro:imu_sensor prefix="${prefix}" />
     <xacro:shadowhand_palm_gazebo prefix="${prefix}" />
   </xacro:macro>
 </robot>


### PR DESCRIPTION
## Proposed changes

Adding a child element to the sensor description of the imu, to be compatible with urdf sensor parser that requires a child element. Current sensor parser is broken anyway, but our fixed version works and needs a sensor type represented by a child element. The name imu will be ignored but you could create a parser for it, that inserts as a plugin to the sensor parser.

## Types of changes

What types of changes does your code introduce?

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

Put an x in the boxes that apply. You can also fill these out after creating the PR. This is a reminder of what we should look for before merging this code. I have:

- [X] Read and follow the [contributing guidelines](https://github.com/shadow-robot/sr_documentation/blob/master/CONTRIBUTING.md).
- [X] Checked that all tests pass with my changes
- [ ] Added tests (automatic or manual) that prove the fix is effective or that the feature works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added the corresponding license to each file and add the current year of any one that you modified.
- [] Tested on real hardware (if appropriate)

Tested with the test function, the rh|lh_imu frame appears correctly and there is no parsing issues on stock urdfdom

