### PR TITLE
sr_description: fix catkin issues

### DIFF
--- a/sr_description/CMakeLists.txt
+++ b/sr_description/CMakeLists.txt
@@ -1,19 +1,21 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(sr_description)
-find_package(catkin REQUIRED COMPONENTS urdf xacro)
-include_directories(${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
+
+find_package(catkin REQUIRED)
 
 catkin_package(
     DEPENDS
-    CATKIN_DEPENDS urdf xacro position_controllers joint_trajectory_controller
+    CATKIN_DEPENDS
     INCLUDE_DIRS
     LIBRARIES
 )
 
 if (CATKIN_ENABLE_TESTING)
+  find_package(urdf REQUIRED)
+
+  include_directories(${urdf_INCLUDE_DIRS})
   catkin_add_gtest(test_sr_description_urdf test/test_sr_description_urdf.cpp)
-  add_dependencies(test_sr_description_urdf ${catkin_EXPORTED_TARGETS})
-  target_link_libraries(test_sr_description_urdf ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+  target_link_libraries(test_sr_description_urdf ${urdf_LIBRARIES})
 endif()
 
 install(DIRECTORY arm/

--- a/sr_description/package.xml
+++ b/sr_description/package.xml
@@ -16,21 +16,16 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <!-- Dependencies needed to compile this package. -->
-  <build_depend>urdf</build_depend>
-  <build_depend>xacro</build_depend>
-
-  <!-- Those dependencies are for tests only but won't be installed
-  with rosdep if using test_depend... -->
-  <build_depend>liburdfdom-tools</build_depend>
-  <build_depend>liburdfdom-dev</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
-  <run_depend>urdf</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>position_controllers</run_depend>
   <run_depend>joint_trajectory_controller</run_depend>
 
   <!-- Dependencies needed only for running tests. -->
+  <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>liburdfdom-dev</test_depend>
+  <test_depend>urdf</test_depend>
   <test_depend>gtest</test_depend>
 
 </package>

--- a/sr_robot_msgs/CMakeLists.txt
+++ b/sr_robot_msgs/CMakeLists.txt
@@ -9,7 +9,7 @@ set(MSG_DEPS
   moveit_msgs
 )
 
-find_package(catkin REQUIRED COMPONENTS roslib genmsg message_generation ${MSG_DEPS})
+find_package(catkin REQUIRED COMPONENTS roslib message_generation ${MSG_DEPS})
 
 add_message_files(
   FILES


### PR DESCRIPTION
No need to build-depend on any C++ stuff. catkin just installs some files.
Simplify test dependency. Don't export any dependencies in catkin_package().
