### PR TITLE
Hand model bug fix when using Biotac SP + (version 2) tactile sensors

### DIFF
--- a/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.urdf.xacro
@@ -38,7 +38,7 @@
   <xacro:macro name="lfmetacarpal" params="prefix:=^ reflect:=^ parent">
     <link name="${prefix}lfmetacarpal">
       <inertial>
-        <origin xyz="${reflect*0.05397275/1.7} 0 ${0.038/1.7}" rpy="0 ${reflect*0.9599} 0" />
+        <origin xyz="0 0 0.04" rpy="0 0 0" />
         <mass value="0.030" />
         <inertia ixx="0.0000145" ixy="0.0" ixz="0.0" iyy="0.00001638" iyz="0.0" izz="0.000004272" />
       </inertial>

--- a/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.urdf.xacro
+++ b/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.urdf.xacro
@@ -38,7 +38,7 @@
   <xacro:macro name="lfmetacarpal" params="prefix:=^ reflect:=^ parent">
     <link name="${prefix}lfmetacarpal">
       <inertial>
-        <origin xyz="0 0 0.04" rpy="0 0 0" />
+        <origin xyz="${reflect*0.05397275/1.7} 0 ${0.038/1.7}" rpy="0 ${reflect*0.9599} 0" />
         <mass value="0.030" />
         <inertia ixx="0.0000145" ixy="0.0" ixz="0.0" iyy="0.00001638" iyz="0.0" izz="0.000004272" />
       </inertial>

--- a/sr_description/hand/xacro/thumb/thdistal.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thdistal.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
  Software License Agreement (BSD License)
- Copyright © 2022 belongs to Shadow Robot Company Ltd.
+ Copyright © 2022, 2023 belongs to Shadow Robot Company Ltd.
  All rights reserved.
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/sr_description/hand/xacro/thumb/thdistal.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thdistal.urdf.xacro
@@ -48,7 +48,7 @@
       <joint name="${prefix}THJ1" type="revolute">
         <parent link="${parent}" />
         <child link="${prefix}thdistal_J1_dummy" />
-        <origin xyz="0 0 0.02" rpy="0 0 ${-pi/2}" />
+        <origin xyz="0 0 0.02" rpy="0 0 0" />
         <axis xyz="1 0 0" />
         <limit lower="${20*pi/180}" upper="${20.1*pi/180}" effort="0.0" velocity="2.0" />
         <dynamics damping="0.5" />
@@ -99,7 +99,7 @@
       <joint name="${prefix}th_distal_joint" type="fixed">
         <parent link="${prefix}thmiddle" />
         <child link="${prefix}thdistal" />
-        <origin xyz="0 0.0 0.01" rpy="0 0 ${-pi/2}" />
+        <origin xyz="0 0.0 0.01" rpy="0 0 0" />
       </joint>
       <!-- extra link to imaginary sphere in fingertip for FK/IK calculations -->
       <link name="${prefix}thtip">

--- a/sr_description/hand/xacro/thumb/thmiddle.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thmiddle.urdf.xacro
@@ -44,7 +44,7 @@
         <inertia ixx="0.0000051" ixy="0.0" ixz="0.0" iyy="0.0000051" iyz="0.0" izz="0.00000121" />
       </inertial>
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
+        <origin xyz="0 0 0" rpy="0 0 ${pi/2}" />
         <xacro:if value="${mid_sensor == 'bt_2p'}">
           <geometry name="${prefix}thmiddle_visual">
             <mesh filename="package://sr_description/meshes/components/th_distal/bt_2p/th_distal_bt_2p_adapter.dae"

--- a/sr_description/hand/xacro/thumb/thproximal.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thproximal.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
  Software License Agreement (BSD License)
- Copyright © 2022 belongs to Shadow Robot Company Ltd.
+ Copyright © 2022, 2023 belongs to Shadow Robot Company Ltd.
  All rights reserved.
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/sr_description/hand/xacro/thumb/thproximal.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thproximal.urdf.xacro
@@ -43,7 +43,7 @@
         <inertia ixx="0.0000136" ixy="0.0" ixz="0.0" iyy="0.0000136" iyz="0.0" izz="0.00000313" />
       </inertial>
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
+        <origin xyz="0 0 0" rpy="0 0 ${pi/2}" />
         <geometry name="${prefix}thproximal_visual">
           <mesh filename="package://sr_description/meshes/components/th_proximal/th_proximal_${hand_version}.dae"
           scale="0.001 0.001 0.001" />


### PR DESCRIPTION
## Proposed changes

Fixes #159, a bug in the URDF model of the Hands where a rotation is being wrongly applied to the last link of the thumb when using the fingertips with sensors Biotac SP+ (version 2). This change was missing after we updated the Hands' TF tree [here](https://github.com/shadow-robot/sr_common/pull/144).

Also, the thumb meshes have been correctly oriented to match the thumb links' rotation.

Jira: https://shadowrobot.atlassian.net/browse/SP-565

Example with 0° joint states (thumb):
Before:
![before](https://user-images.githubusercontent.com/107403736/228860681-95f6cb3d-d98a-43e8-93a6-6f50810319de.png)

After:
![After](https://user-images.githubusercontent.com/107403736/228861030-96d8d7f3-a8ab-4b9a-8031-f79f0a29f693.png)


## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
