### PR TITLE
Fix thj2 offset in bt_2p configuration

### DIFF
--- a/sr_description/hand/xacro/thumb/thmiddle.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thmiddle.urdf.xacro
@@ -93,13 +93,7 @@
     <joint name="${prefix}THJ2" type="revolute">
       <parent link="${parent}" />
       <child link="${prefix}thmiddle" />
-      <xacro:if value="${mid_sensor == 'bt_2p'}">
-        <origin xyz="0 0 0.01" rpy="0 0 0" />
-        <!-- FIXME: z offset is too large -->
-      </xacro:if>
-      <xacro:unless value="${mid_sensor == 'bt_2p'}">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-      </xacro:unless>
+      <origin xyz="0 0 0" rpy="0 0 0" />
       <axis xyz="1 0 0" />
       <limit lower="${-40/180*pi}" upper="${40/180*pi}" effort="2.0" velocity="2.0" />
       <dynamics damping="0.1" />

--- a/sr_description/hand/xacro/thumb/thmiddle.urdf.xacro
+++ b/sr_description/hand/xacro/thumb/thmiddle.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
  Software License Agreement (BSD License)
- Copyright © 2022-2023 belongs to Shadow Robot Company Ltd.
+ Copyright © 2022-2024 belongs to Shadow Robot Company Ltd.
  All rights reserved.
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:


### PR DESCRIPTION
This is an 11 year old fixme that simply asked to remove an arbitrary constant that broke the model. The links are centered on the joint axis already just as with the other configurations.

We just found that through a lot of manual calibration work..

Greetings from Hamburg